### PR TITLE
fix: Use modifiable list

### DIFF
--- a/crawler/src/main/java/de/unidisk/dao/ProjectDAO.java
+++ b/crawler/src/main/java/de/unidisk/dao/ProjectDAO.java
@@ -320,7 +320,7 @@ public class ProjectDAO  implements IProjectRepository {
     }
 
     private List<Project> mergeProjectWithSubprojects(Project project){
-        final List<Project> projects = Arrays.asList(project);
+        final List<Project> projects = new ArrayList<Project>(Arrays.asList(project));
         projects.addAll(project.getSubprojects());
         return projects;
     }


### PR DESCRIPTION
`Arrays.asList` gibt scheinbar eine Liste mit fester Größe zurück, die anschließende Zeile hat dann einen Fehler verursacht.