### PR TITLE
Feature: TopicScores rating shared

### DIFF
--- a/crawler/src/main/java/de/unidisk/dao/ScoringDAO.java
+++ b/crawler/src/main/java/de/unidisk/dao/ScoringDAO.java
@@ -6,11 +6,11 @@ import de.unidisk.entities.hibernate.SearchMetaData;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 
-public interface ScoringDAO {
-    default ScoredInput addScore(Input input, double score, SearchMetaData smd) {
+public interface ScoringDAO<TScoreInput extends ScoredInput > {
+    default TScoreInput addScore(Input input, double score, SearchMetaData smd) {
         Session currentSession = HibernateUtil.getSessionFactory().openSession();
         Transaction tnx = currentSession.beginTransaction();
-        ScoredInput scoredInput = queryInput(input, currentSession);
+        TScoreInput scoredInput = queryInput(input, currentSession);
 
         scoredInput.setScore(score);
         scoredInput.setSearchMetaData(smd);
@@ -20,5 +20,5 @@ public interface ScoringDAO {
         return scoredInput;
     }
 
-    ScoredInput queryInput(Input input, Session currenSesstion);
+    TScoreInput queryInput(Input input, Session currenSesstion);
 }

--- a/crawler/src/main/java/de/unidisk/dao/TopicScoreDAO.java
+++ b/crawler/src/main/java/de/unidisk/dao/TopicScoreDAO.java
@@ -3,17 +3,16 @@ package de.unidisk.dao;
 import de.unidisk.common.exceptions.EntityNotFoundException;
 import de.unidisk.entities.hibernate.*;
 import org.hibernate.Session;
-import org.hibernate.Transaction;
 
 import java.util.List;
 import java.util.Optional;
 
-public class TopicScoreDAO implements ScoringDAO {
+public class TopicScoreDAO implements ScoringDAO<TopicScore> {
     public TopicScoreDAO() {
     }
 
     @Override
-    public ScoredInput queryInput(Input input, Session currentSession) {
+    public TopicScore queryInput(Input input, Session currentSession) {
         return currentSession.createQuery("select ts from TopicScore ts where ts.topic.id = :id ", TopicScore.class)
                 .setParameter("id", input.getId())
                 .uniqueResultOptional()
@@ -22,7 +21,7 @@ public class TopicScoreDAO implements ScoringDAO {
 
     @Override
     public TopicScore addScore(Input input, double score, SearchMetaData smd){
-        return  (TopicScore) ScoringDAO.super.addScore(input,score,smd);
+        return ScoringDAO.super.addScore(input,score,smd);
     }
 
     private TopicScore findOrFail(int topicScoreId) throws EntityNotFoundException {

--- a/crawler/src/main/java/de/unidisk/dao/TopicScoreDAO.java
+++ b/crawler/src/main/java/de/unidisk/dao/TopicScoreDAO.java
@@ -5,6 +5,7 @@ import de.unidisk.entities.hibernate.*;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 
+import java.util.List;
 import java.util.Optional;
 
 public class TopicScoreDAO implements ScoringDAO {
@@ -17,6 +18,11 @@ public class TopicScoreDAO implements ScoringDAO {
                 .setParameter("id", input.getId())
                 .uniqueResultOptional()
                 .orElse(new TopicScore((Topic) input));
+    }
+
+    @Override
+    public TopicScore addScore(Input input, double score, SearchMetaData smd){
+        return  (TopicScore) ScoringDAO.super.addScore(input,score,smd);
     }
 
     private TopicScore findOrFail(int topicScoreId) throws EntityNotFoundException {
@@ -36,8 +42,41 @@ public class TopicScoreDAO implements ScoringDAO {
         final TopicScore updatedScore = HibernateUtil.execute(session -> {
             score.setResultRelevance(relevance);
             session.update(score);
+            final Topic topic = score.getTopic();
+            final int projectId = topic.getProjectId();
+
+            final List<TopicScore> similarScores = this.findSimilarTopicScoresOfProject(projectId, topic.getName(), session);
+            for(TopicScore similarScore : similarScores){
+                if(similarScore.getId() == score.getId())
+                    continue;
+
+                similarScore.setResultRelevance(relevance);
+                session.update(similarScore);
+            }
+
             return score;
         });
         return updatedScore;
+    }
+
+    private List<TopicScore> findSimilarTopicScoresOfProject(int projectId, String topicName, Session session) {
+
+        final Project parentProject = getParentProject(projectId,session);
+
+        return session.createQuery("select distinct ts from Project p " +
+                "INNER JOIN Project sp ON sp.parentProjectId = p.id "+
+                "INNER JOIN Topic t on t.projectId = p.id OR t.projectId = sp.id " +
+                "INNER JOIN TopicScore ts on t.id = ts.topic.id " +
+                "WHERE t.name = :topic AND (p.id = :projectId OR sp.id = :projectId)", TopicScore.class)
+                .setParameter("topic", topicName)
+                .setParameter("projectId", parentProject.getId()).getResultList();
+    }
+
+    private Project getParentProject(int projectId, Session session){
+        final Project p = session.createQuery("SELECT p from Project p where p.id = :id", Project.class)
+                    .setParameter("id",projectId).getSingleResult();
+        if(p.getProjectSubtype() == ProjectSubtype.DEFAULT)
+                return p;
+        return p.getParentProject();
     }
 }

--- a/crawler/src/main/java/de/unidisk/entities/hibernate/Project.java
+++ b/crawler/src/main/java/de/unidisk/entities/hibernate/Project.java
@@ -49,6 +49,10 @@ public class Project {
     @Enumerated(EnumType.STRING)
     private ProjectSubtype projectSubtype;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parentProjectId", insertable = false, updatable = false)
+    private Project parentProject;
+
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "parentProjectId", cascade = CascadeType.ALL, orphanRemoval = true)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Project> subprojects;
@@ -165,5 +169,9 @@ public class Project {
 
     public void setSubprojects(List<Project> subprojects) {
         this.subprojects = subprojects;
+    }
+
+    public Project getParentProject() {
+        return parentProject;
     }
 }

--- a/crawler/src/test/de/unidisk/entities/TopicScoreTests.java
+++ b/crawler/src/test/de/unidisk/entities/TopicScoreTests.java
@@ -68,8 +68,7 @@ public class TopicScoreTests implements HibernateLifecycle {
                 topicDAO.createTopic(topic.getName()+"1",subproject.getId())
             };
 
-            for(int i = 0; i < subprojectTopics.length;i++){
-                final Topic t = subprojectTopics[i];
+            for (final Topic t : subprojectTopics) {
                 final TopicScore score = topicScoreDAO.addScore(t, 1, metaData);
                 topicScores.add(score);
             }

--- a/crawler/src/test/de/unidisk/entities/TopicScoreTests.java
+++ b/crawler/src/test/de/unidisk/entities/TopicScoreTests.java
@@ -11,8 +11,13 @@ import org.junit.jupiter.api.Test;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TopicScoreTests implements HibernateLifecycle {
 
@@ -36,4 +41,51 @@ public class TopicScoreTests implements HibernateLifecycle {
         assertEquals(ResultRelevance.RELEVANT, ratedScore.getResultRelevance());
     }
 
+    @Test
+    public void rateScoreOfSubproject() throws DuplicateException, MalformedURLException, EntityNotFoundException {
+        final ProjectDAO projectDAO = new ProjectDAO();
+        final TopicDAO topicDAO = new TopicDAO();
+        final TopicScoreDAO topicScoreDAO = new TopicScoreDAO();
+        final SearchMetaDataDAO searchMetaDataDAO = new SearchMetaDataDAO();
+        final University university = new UniversityDAO().addUniversity("test");
+        SearchMetaData metaData = searchMetaDataDAO.createMetaData(new URL("http://www.uni-potsdam.de/home"), university.getId(),
+                ZonedDateTime.now().toEpochSecond());
+        final Project project = projectDAO.createProject(new CreateProjectParams("15","test"));
+        final Topic topic = topicDAO.createTopic("25",project.getId());
+
+        final ProjectSubtype[] subtypes = new ProjectSubtype[]{ProjectSubtype.BY_TOPICS, ProjectSubtype.CUSTOM_ONLY};
+        topicScoreDAO.addScore(topic, 1, metaData);
+        final List<TopicScore> topicScores = new ArrayList<>();
+
+        for(ProjectSubtype subtype : subtypes){
+            final Project subproject =  projectDAO.createProject(CreateProjectParams.subproject(
+                    project.getId(),
+                    subtype
+            ));
+            final Topic[] subprojectTopics = new Topic[]{
+                topicDAO.createTopic(topic.getName(),subproject.getId()),
+                // This topic should not be affected
+                topicDAO.createTopic(topic.getName()+"1",subproject.getId())
+            };
+
+            for(int i = 0; i < subprojectTopics.length;i++){
+                final Topic t = subprojectTopics[i];
+                final TopicScore score = topicScoreDAO.addScore(t, 1, metaData);
+                topicScores.add(score);
+            }
+        }
+
+        final ResultRelevance newRelevance = ResultRelevance.RELEVANT;
+
+        topicScoreDAO.rateScore(topicScores.get(0).getId(), newRelevance);
+        List<TopicScore> ratedScores = HibernateUtil.execute(session ->
+             session.createQuery("SELECT ts from TopicScore ts where ts.resultRelevance <> :relevance  ", TopicScore.class)
+                     .setParameter("relevance", ResultRelevance.NONE).list()
+        );
+        assertEquals(3, ratedScores.size());
+        for(TopicScore score : ratedScores){
+            assertEquals(topic.getName(), score.getTopic().getName());
+            assertEquals(newRelevance, score.getResultRelevance());
+        }
+    }
 }

--- a/crawler/src/test/de/unidisk/entities/TopicScoreTests.java
+++ b/crawler/src/test/de/unidisk/entities/TopicScoreTests.java
@@ -30,7 +30,7 @@ public class TopicScoreTests implements HibernateLifecycle {
         SearchMetaData metaData = new SearchMetaDataDAO().createMetaData(new URL("http://www.uni-potsdam.de/home"), university.getId(),
                 ZonedDateTime.now().toEpochSecond());
 
-       return (TopicScore) new TopicScoreDAO().addScore(topic, 1, metaData);
+       return new TopicScoreDAO().addScore(topic, 1, metaData);
     }
 
     @Test


### PR DESCRIPTION
Relevanzbewertungen eines Themenscores werden automatisch auf identische Scores des gleichen Projekts übertragen.

Hat ein Projekt beispielsweise das Thema Obst, dann gibt es nach der Bewertung 3 Scores (1 für jedes Unterprojekt). Diese haben eventuell alle die gleiche Url wie http://www.example.com. Da für die Relevanz nur der Inhalt entscheident ist und dieser bei gleicher Url identisch ist, kann auch die Bewertung übernommen werden. Dies ist jedoch nur für das gleiche Thema möglich. Die Seite könnte bspw. für das Thema Obst relevant sein aber nicht für Medizin obwohl beide die gleiche Ergebnisurl haben.